### PR TITLE
Also catch other possible macro names for track forward/back buttons

### DIFF
--- a/GoogleMusic/AppDelegate.m
+++ b/GoogleMusic/AppDelegate.m
@@ -101,6 +101,7 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
             return NULL;
             
 		case NX_KEYTYPE_FAST:   // F9
+		case NX_KEYTYPE_NEXT:
 			if( keyState == 0 ) {
                     [self performSelectorOnMainThread:@selector(forwardAction)
                                            withObject:nil waitUntilDone:NO];
@@ -108,6 +109,7 @@ static CGEventRef event_tap_callback(CGEventTapProxy proxy,
             return NULL;
             
 		case NX_KEYTYPE_REWIND:   // F7
+		case NX_KEYTYPE_PREVIOUS:
 			if( keyState == 0 ) {
                     [self performSelectorOnMainThread:@selector(backAction)
                                            withObject:nil waitUntilDone:NO];


### PR DESCRIPTION
On a keyboard I have (and possibly on the actual laptop keys itself), the standard track forward/backward buttons don't do anything.  I traced this to the fact that they're emitting key press events as `NX_KEYTYPE_NEXT`/`NX_KEYTYPE_PREVIOUS` instead of `NX_KEYTYPE_FAST`/`NX_KEYTYPE_PREVIOUS`.  So this PR just adds those to the possible key codes that are caught and treated as forward/backward tracks.
